### PR TITLE
move Encoding::FixLatin to a test prereq

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,8 +17,8 @@ version = 1.01
 
 [Prereqs]
 perl                  = 5.014
-Encoding::FixLatin    = 1.03
 
 [Prereqs / TestRequires]
 Test::More            = 0.90
+Encoding::FixLatin    = 1.03
 


### PR DESCRIPTION
While this module is not really any use without Encoding::FixLatin,
strictly speaking it does not require it.  It is only needed by the
tests.  Moving it to a test prereq breaks a circular dependency for
systems that want to install 'recommends' prereqs.